### PR TITLE
Update date.go

### DIFF
--- a/date.go
+++ b/date.go
@@ -96,8 +96,8 @@ func (date *goDate) convert() {
 func (date *goDate) initMapping() {
 	date.phpToGoFormat = map[string]string{
 		"Y": "2006",
-		"m": "02",
-		"d": "01",
+		"m": "01",
+		"d": "02",
 		"H": "15",
 		"i": "04",
 		"s": "05",


### PR DESCRIPTION
fix bug
the month and the day  is reversed

for example 
`
fmt.Print(pgo.Date("Y-m-d H:i:s", time.Now().Unix()))  //output 2020-22-07 17:58:08 
` 
the month is 22,that is wrong
